### PR TITLE
PM-58 - Update travis file so it is identical on all environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,18 @@ language: ruby
 rvm:
  — 2.7.1
 deploy:
+  edge: true
   provider: cloudfoundry
   api: $API_URI
   username: $USERNAME
   password: $PASSWORD
   organization: $ORG_NAME
-  space: $SPACE_TYPE_DEVELOPMENT
   deployment_strategy: rolling
+  space: $SPACE_NAME
   on:
     repo: Crown-Commercial-Service/pmp-idam
-    branch: develop
+    all_branches: true
+    condition: $DEPLOY_BRANCH = TRUE
 env:
   global:
     - RAILS_ENV=test
@@ -20,7 +22,6 @@ services:
   - postgresql
 addons:
   postgresql: '11'
-sudo: true
 before_script:
   - sudo apt-get -qq update
   - sudo apt-get install -y postgresql-11-postgis-2.5


### PR DESCRIPTION
In this PR I have updated the travis file so that it can be identical on all branches.

I will walk through all the changes I made:

```
edge: true
```
Sets our environment to use the v2 of travis which allows for rolling deployments.
&nbsp;


```
space: $SPACE_NAME
```
I've set this up on travis so the four branches that map to an environment have the correct space name. These names can be seen on GPaaS.
&nbsp;


```
all_branches: true
condition: $DEPLOY_BRANCH = TRUE
```
$DEPLOY_BRANCH is set to TRUE for the four branches that map to an environment. This way we don't have to specify which branches need to deploy allowing us to have the same travis file for all branches.


`sudo: true` was removed as it is depreciated