### PR TITLE
PM-86 - Encrypt email in URL so it is not sent to GA

### DIFF
--- a/app/controllers/base/passwords_controller.rb
+++ b/app/controllers/base/passwords_controller.rb
@@ -11,7 +11,7 @@ module Base
       if @response.success?
         Rails.logger.info 'FORGOT PASSWORD EMAIL SENT'
 
-        redirect_to base_edit_user_password_path(email: forgot_password_params[:email])
+        redirect_to base_edit_user_password_path(e: TextEncryptor.encrypt(forgot_password_params[:email]))
       else
         Rails.logger.info "FORGOT PASSWORD FAILED: #{get_error_list(@response.errors)}"
 
@@ -20,7 +20,7 @@ module Base
     end
 
     def edit
-      @response = Cognito::ConfirmPasswordReset.new({ email: params[:email] })
+      @response = Cognito::ConfirmPasswordReset.new({ email: TextEncryptor.decrypt(params[:e]) })
     end
 
     def update

--- a/app/controllers/base/registrations_controller.rb
+++ b/app/controllers/base/registrations_controller.rb
@@ -12,7 +12,7 @@ module Base
       @result = Cognito::SignUpUser.call(sign_up_params)
       if @result.success?
         Rails.logger.info 'SIGN UP ATTEMPT SUCCESSFUL'
-        redirect_to base_users_confirm_path(email: sign_up_params[:email])
+        redirect_to base_users_confirm_path(e: TextEncryptor.encrypt(sign_up_params[:email]))
       else
         fail_create
       end

--- a/app/controllers/base/users_controller.rb
+++ b/app/controllers/base/users_controller.rb
@@ -2,6 +2,8 @@
 
 module Base
   class UsersController < ApplicationController
+    before_action :assign_email
+
     def confirm_new
       @result = Cognito::ConfirmSignUp.new
     end
@@ -19,10 +21,10 @@ module Base
     end
 
     def resend_confirmation_email
-      result = Cognito::ResendConfirmationCode.call(params[:email])
+      result = Cognito::ResendConfirmationCode.call(@email)
       Rails.logger.info 'ACCOUNT ACTIVATION EMAIL RESENT'
 
-      redirect_to base_users_confirm_path_path(email: params[:email]), error: result.error
+      redirect_to base_users_confirm_path_path(e: params[:e]), error: result.error
     end
 
     private
@@ -32,6 +34,10 @@ module Base
         :confirmation_code,
         :email
       )
+    end
+
+    def assign_email
+      @email = params[:e].present? ? TextEncryptor.decrypt(params[:e]) : confirm_sign_up_params[:email]
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,4 +31,8 @@ module ApplicationHelper
       yield(display_error(model, attribute), any_errors)
     end
   end
+
+  def parameters_without_user_details
+    request.parameters.except(:cognito_sign_in_user)
+  end
 end

--- a/app/services/text_encryptor.rb
+++ b/app/services/text_encryptor.rb
@@ -1,0 +1,21 @@
+module TextEncryptor
+  def self.encrypt(text)
+    text = text.to_s unless text.is_a? String
+
+    len   = ActiveSupport::MessageEncryptor.key_len
+    salt  = SecureRandom.hex len
+    key   = ActiveSupport::KeyGenerator.new(Rails.application.secrets.secret_key_base).generate_key salt, len
+    crypt = ActiveSupport::MessageEncryptor.new key
+    encrypted_data = crypt.encrypt_and_sign text
+    "#{salt}$$#{encrypted_data}"
+  end
+
+  def self.decrypt(text)
+    salt, data = text.split '$$'
+
+    len   = ActiveSupport::MessageEncryptor.key_len
+    key   = ActiveSupport::KeyGenerator.new(Rails.application.secrets.secret_key_base).generate_key salt, len
+    crypt = ActiveSupport::MessageEncryptor.new key
+    crypt.decrypt_and_verify data
+  end
+end

--- a/app/views/base/sessions/new.html.erb
+++ b/app/views/base/sessions/new.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render partial: 'shared/error_summary', locals: { errors: @result.errors } %>
 
-    <%= form_with model: @result, url: base_user_session_path(request.parameters),  html: { novalidate: true }, local: true, method: :post do |f| %>
+    <%= form_with model: @result, url: base_user_session_path(parameters_without_user_details),  html: { novalidate: true }, local: true, method: :post do |f| %>
       <%= form_group_with_error(f.object, :email) do |displayed_error, any_errors| %>
         <%= f.label :email, t('.email_address'), class: 'govuk-label govuk-label--m govuk-!-margin-bottom-0' %>
         <span id="email-hint" class="govuk-hint govuk-!-width-three-quarters">

--- a/app/views/base/users/confirm_new.html.erb
+++ b/app/views/base/users/confirm_new.html.erb
@@ -8,18 +8,18 @@
     </h1>
 
     <p class="govuk-body-l">
-      <%= t('.lead', location: params[:email].present? ? params[:email]: t('.you')) %>
+      <%= t('.lead', location: @email.present? ? @email: t('.you')) %>
     </p>
 
-    <%= form_with model: @result, url: base_users_confirm_path(email: params[:email]),  html: { novalidate: true }, local: true, method: :post do |f| %>
+    <%= form_with model: @result, url: base_users_confirm_path(e: params[:e]),  html: { novalidate: true }, local: true, method: :post do |f| %>
       <%= form_group_with_error(f.object, :confirmation_code) do |displayed_error, any_errors| %>
         <%= f.label :confirmation_code, t('.confirmation_code'), class: 'govuk-label govuk-!-margin-bottom-0' %>
         <%= displayed_error %>
         <%= f.text_field :confirmation_code, class: "govuk-input govuk-input--width-10 #{'govuk-input--error' if any_errors}", type: 'number' %>
       <% end %>
 
-      <% if params[:email].present? %>
-        <%= f.hidden_field :email, value: params[:email] %>
+      <% if @email.present? %>
+        <%= f.hidden_field :email, value: @email %>
       <% else %>
         <%= form_group_with_error(f.object, :email) do |displayed_error, any_errors| %>
           <%= f.label :email, t('.email'), class: 'govuk-label govuk-!-margin-bottom-0' %>
@@ -31,9 +31,9 @@
       <%= f.submit t('common.continue'), class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7", 'aria-label': t('common.continue') %>
     <% end %>
 
-    <% if params[:email].present? %>
+    <% if @email.present? %>
       <p class="govuk-body govuk-!-margin-bottom-7">
-        <%= t('.resend_the_confirmation_email_html', link: base_resend_confirmation_email_path(email: params[:email])) %>
+        <%= t('.resend_the_confirmation_email_html', link: base_resend_confirmation_email_path(e: params[:e])) %>
       </p>
     <% end %>
   </div>

--- a/spec/controllers/base/passwords_controller_spec.rb
+++ b/spec/controllers/base/passwords_controller_spec.rb
@@ -29,13 +29,13 @@ RSpec.describe Base::PasswordsController do
       let(:email) { 'test@test.com' }
 
       it 'redirects to the edit password page' do
-        expect(response).to redirect_to base_edit_user_password_path(email: email)
+        expect(response.location.split('=')[0]).to eq "#{base_edit_user_password_url}?e"
       end
     end
   end
 
   describe 'GET edit' do
-    before { get :edit }
+    before { get :edit, params: { e: TextEncryptor.encrypt('test@email.com') } }
 
     it 'renders the edit page' do
       expect(response).to render_template(:edit)

--- a/spec/controllers/base/registrations_controller_spec.rb
+++ b/spec/controllers/base/registrations_controller_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe Base::RegistrationsController do
     end
 
     context 'when all the information is valid' do
-      it 'redirects to base_users_confirm_path' do
-        expect(response).to redirect_to base_users_confirm_path(email: email)
+      it 'redirects to base_users_confirm_path with a param e' do
+        expect(response.location.split('=')[0]).to eq "#{base_users_confirm_url}?e"
       end
     end
   end

--- a/spec/controllers/base/users_controller_spec.rb
+++ b/spec/controllers/base/users_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Base::UsersController do
   describe 'GET confirm_new' do
-    before { get :confirm_new }
+    before { get :confirm_new, params: { e: TextEncryptor.encrypt('test@email.com') } }
 
     it 'renders the confirm_new page' do
       expect(response).to render_template(:confirm_new)
@@ -39,11 +39,11 @@ RSpec.describe Base::UsersController do
 
     before do
       allow(Cognito::ResendConfirmationCode).to receive(:call).with(email).and_return(Cognito::ResendConfirmationCode.new(email))
-      get :resend_confirmation_email, params: { email: email }
+      get :resend_confirmation_email, params: { e: TextEncryptor.encrypt(email) }
     end
 
     it 'redirects to the confirm page' do
-      expect(response).to redirect_to base_users_confirm_path_path(email: email)
+      expect(response.location.split('=')[0]).to eq "#{base_users_confirm_url}?e"
     end
   end
 end

--- a/spec/services/text_encryptor_spec.rb
+++ b/spec/services/text_encryptor_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe TextEncryptor do
+  let(:email) { 'test@email.com' }
+
+  describe '.encrypt' do
+    it 'successfully encrypts an email address' do
+      expect(described_class.encrypt(email)).not_to include email
+    end
+  end
+
+  describe '.decrypt' do
+    let(:encrypted_email) { described_class.encrypt(email) }
+
+    it 'successfully decrypts an encrypted email address' do
+      expect(described_class.decrypt(encrypted_email)).to eq email
+    end
+  end
+end


### PR DESCRIPTION
- Implement changes to encrypt email in URL

Changes are copied from tailspend:
- https://github.com/Crown-Commercial-Service/tailspend-idam/pull/23
- https://github.com/Crown-Commercial-Service/tailspend-idam/pull/25