### PR TITLE
Fix email validation to use standard rails regex

### DIFF
--- a/app/services/cognito/sign_in_user.rb
+++ b/app/services/cognito/sign_in_user.rb
@@ -7,7 +7,7 @@ module Cognito
     attr_accessor :error, :needs_password_reset, :needs_confirmation
 
     validates_presence_of :email, :password
-    validates :email, format: { with: /\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i }
+    validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
     validate :cookies_should_be_enabled, :redirect_uri_known
 
     def initialize(email, password, client_id, cookies_disabled, redirect_uri)

--- a/app/services/cognito/sign_up_user.rb
+++ b/app/services/cognito/sign_up_user.rb
@@ -12,6 +12,7 @@ module Cognito
 
     include PasswordValidator
 
+    validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
     validate :domain_in_allow_list, unless: -> { errors[:email].any? }
     validate :organisation_present
     attr_reader :email, :first_name, :last_name, :summary_line, :password, :password_confirmation, :organisation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,7 +102,8 @@ en:
         cognito/sign_up_user:
           attributes:
             email:
-              blank: Enter an email address in the correct format, like name@example.com
+              blank: You must enter your email address in the correct format, like name@example.com
+              invalid: You must enter your email address in the correct format, like name@example.com
               not_on_allow_list: You must use a public sector email
             first_name:
               blank: Enter your first name

--- a/spec/services/cognito/sign_in_user_spec.rb
+++ b/spec/services/cognito/sign_in_user_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe Cognito::SignInUser do
           expect(sign_in_user.errors[:email].first).to eq 'You must enter your email address in the correct format, like name@example.com'
         end
       end
+
+      context 'and the domains contain a dash' do
+        let(:email) { 'test@digital.cabinet-office.gov.uk' }
+
+        it 'is valid' do
+          expect(sign_in_user.valid?).to be true
+        end
+      end
     end
 
     context 'when considering the password' do

--- a/spec/services/cognito/sign_up_user_spec.rb
+++ b/spec/services/cognito/sign_up_user_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Cognito::SignUpUser do
 
         it 'has the correct error message' do
           sign_up_user.valid?
-          expect(sign_up_user.errors[:email].first).to eq 'Enter an email address in the correct format, like name@example.com'
+          expect(sign_up_user.errors[:email].first).to eq 'You must enter your email address in the correct format, like name@example.com'
         end
       end
 
@@ -56,6 +56,28 @@ RSpec.describe Cognito::SignUpUser do
         it 'has the correct error message' do
           sign_up_user.valid?
           expect(sign_up_user.errors[:email].first).to eq 'You must use a public sector email'
+        end
+      end
+
+      context 'and it is not in the correct format' do
+        let(:email) { 'Elma' }
+
+        it 'is not valid' do
+          expect(sign_up_user.valid?).to be false
+        end
+
+        it 'has the correct error message' do
+          sign_up_user.valid?
+          expect(sign_up_user.errors[:email].first).to eq 'You must enter your email address in the correct format, like name@example.com'
+        end
+      end
+
+      context 'and the domains contain a dash' do
+        let(:email) { 'elma@blade.xenoblade-x.ca.us' }
+        let(:domain) { 'blade.xenoblade-x.ca.us' }
+
+        it 'is valid' do
+          expect(sign_up_user.valid?).to be true
         end
       end
     end


### PR DESCRIPTION
- Add test to catch email with dash
- Update validation so that it allows emails with dashes
- Add tests for email format validation
- Add validation of email format

This regex comes from: https://stackoverflow.com/questions/22993545/ruby-email-validation-with-regex