### PR TITLE
Add the better html gem and make some updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,9 @@ gem 'canonical-rails', github: 'jumph4x/canonical-rails'
 # For environment variables
 gem 'vault'
 
+# From i18n but has some helpers that might be useful
+gem 'better_html'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,6 +337,7 @@ DEPENDENCIES
   arask (= 1.2.3)
   aws-sdk-cognitoidentityprovider (~> 1.65.0)
   aws-sdk-s3 (~> 1)
+  better_html
   bootsnap (>= 1.4.2)
   brakeman
   byebug

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  include BetterHtml::Helpers
+
   def error_id(attribute)
     "#{attribute}-error"
   end

--- a/app/views/base/passwords/confirm_new.html.erb
+++ b/app/views/base/passwords/confirm_new.html.erb
@@ -10,7 +10,8 @@
     </p>
 
     <p class="govuk-body govuk-!-margin-bottom-7">
-      <%= t('.text01') %> <%= t('.text02_html') %>.
+      <%= t('.text') %>
+      <%= link_to(t('.support'), 'mailto:support@crowncommercial.gov.uk', class: 'govuk-link--no-visited-state') %>
     </p>
   </div>
 </div>

--- a/app/views/base/passwords/edit.html.erb
+++ b/app/views/base/passwords/edit.html.erb
@@ -18,7 +18,8 @@
     </p>
 
     <p class="govuk-body govuk-!-margin-bottom-7">
-      <%= t('.text_html') %>
+      <%= t('.text') %>
+      <%= link_to(t('.support'), 'mailto:support@crowncommercial.gov.uk', class: 'govuk-link--no-visited-state') %>
     </p>
 
     <p class="govuk-body-l">

--- a/app/views/base/registrations/new.html.erb
+++ b/app/views/base/registrations/new.html.erb
@@ -53,7 +53,7 @@
             </span>
           </span>
           <%= displayed_error %>
-          <div id="selected-autocomplete-option" class="govuk-!-width-three-quarters" <%= "hidden" unless f.object.summary_line.present? %>>
+          <div id="selected-autocomplete-option" class="govuk-!-width-three-quarters" <%= html_attributes(hidden: nil) unless f.object.summary_line.present? %>>
             <p class="govuk-body govuk-!-font-weight-regular govuk-tag govuk-tag--green"><strong>Selected option: </strong><span><%= f.object.summary_line %></span></p>
           </div>
           <div id="my-autocomplete-container" class="govuk-!-width-three-quarters">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,8 +136,8 @@ en:
       confirm_new:
         heading: A reset email has been sent.
         lead: If the email address you’ve entered belongs to a registered organisation, we’ll send a link to reset the password.
-        text01: If you don’t receive this, email
-        text02_html: <a href="mailto:support@crowncommercial.gov.uk">support@crowncommercial.gov.uk</a>
+        support: support@crowncommercial.gov.uk
+        text: If you don’t receive this, email
       edit:
         confirm_new_password: Confirm new password
         heading: Reset your password
@@ -146,7 +146,8 @@ en:
         lead1: If the email address you’ve entered belongs to a registered organisation, we’ll send instructions to reset the password.
         new_password: New password
         password: Your password must have
-        text_html: If you don’t receive this, email <a href="mailto:support@crowncommercial.gov.uk">support@crowncommercial.gov.uk</a>
+        support: support@crowncommercial.gov.uk
+        text: If you don’t receive this, email
         verify_code: Verification code
       new:
         email: Email address


### PR DESCRIPTION
- Explicitly add the better html gem
- Update the registration pages
- Make changes for the password controller

This came from the new update to i18n and should make out HTML safer