### PR TITLE
PM-94 - Add the host header restriction

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,4 +102,6 @@ Rails.application.configure do
     'X-XSS-Protection' => '1; mode=block',
     'X-Content-Type-Options' => 'nosniff'
   }
+
+  application.config.hosts << '.printmarketplace.crowncommercial.gov.uk'
 end


### PR DESCRIPTION
Ticket: [PM-94](https://crowncommercialservice.atlassian.net/browse/PM-94)

`printmarketplace.crowncommercial.gov.uk` all environments have the PM sub domain.
We can test this using postman when it has been deployed.