### PR TITLE
PM-95 - Add rate limiting on the API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,9 @@ gem 'canonical-rails', github: 'jumph4x/canonical-rails'
 # For environment variables
 gem 'vault'
 
+# Add rate limiting on the API
+gem 'rack-attack'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,8 @@ GEM
     raabro (1.4.0)
     racc (1.6.0)
     rack (2.2.3)
+    rack-attack (6.6.1)
+      rack (>= 1.0, < 3)
     rack-proxy (0.7.2)
       rack
     rack-test (1.1.0)
@@ -348,6 +350,7 @@ DEPENDENCIES
   pg (~> 1.3.5)
   pry-rails
   puma (~> 5.6)
+  rack-attack
   rails (~> 6.1.5)
   rails-controller-testing (>= 1.0.5)
   rest-client (~> 2.1)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,3 @@
+Rack::Attack.throttle('requests to organisation-search api by ip ', limit: 100, period: 60) do |request|
+  request.ip if request.path == '/api/v1/organisation-search'
+end


### PR DESCRIPTION
Ticket: [PM-95](https://crowncommercialservice.atlassian.net/browse/PM-95)

Add a rate limit to the API to prevent it from being overused.
This is because we allow users to access the API without authenticating.

Without authentication it is difficult to limit the access to the API, however, at the very least, we can add the rate limiting to make sure it is not overused.