### PR TITLE
PM-92 - Address various issues where user enumerate was possible

### DIFF
--- a/app/services/cognito/forgot_password.rb
+++ b/app/services/cognito/forgot_password.rb
@@ -15,7 +15,9 @@ module Cognito
 
     def call
       forgot_password if valid?
-    rescue Aws::CognitoIdentityProvider::Errors::UserNotFoundException, Aws::CognitoIdentityProvider::Errors::InvalidParameterException
+    rescue Aws::CognitoIdentityProvider::Errors::UserNotFoundException
+      # We do nothing as we don't want people to be able enumerate users
+    rescue Aws::CognitoIdentityProvider::Errors::InvalidParameterException
       errors.add(:base, :user_not_found)
     rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
       errors.add(:base, e.message)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -146,7 +146,7 @@ en:
         lead1: If the email address you’ve entered belongs to a registered organisation, we’ll send instructions to reset the password.
         new_password: New password
         password: Your password must have
-        text_html: If you don’t receive this, email <a href="mailto:support@crowncommercial.gov.uk">support@crowncommercial.gov.uk</a>
+        text_html: If you don’t receive this, email <a href="mailto:support@crowncommercial.gov.uk" class="govuk-link--no-visited-state">support@crowncommercial.gov.uk</a>
         verify_code: Verification code
       new:
         email: Email address

--- a/spec/controllers/base/passwords_controller_spec.rb
+++ b/spec/controllers/base/passwords_controller_spec.rb
@@ -10,26 +10,61 @@ RSpec.describe Base::PasswordsController do
   end
 
   describe 'POST create' do
-    before do
-      # rubocop:disable RSpec/AnyInstance
-      allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
-      # rubocop:enable RSpec/AnyInstance
-      post :create, params: { cognito_forgot_password: { email: email } }
-    end
+    context 'when no exception is raised' do
+      before do
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
+        # rubocop:enable RSpec/AnyInstance
+        post :create, params: { cognito_forgot_password: { email: email } }
+      end
 
-    context 'when the email is invalid' do
-      let(:email) { 'testtest.com' }
+      context 'when the email is invalid' do
+        let(:email) { 'testtest.com' }
 
-      it 'render to the new page' do
-        expect(response).to render_template(:new)
+        it 'render to the new page' do
+          expect(response).to render_template(:new)
+        end
+      end
+
+      context 'when the email is valid' do
+        let(:email) { 'test@test.com' }
+
+        it 'redirects to the edit password page' do
+          expect(response.location.split('=')[0]).to eq "#{base_edit_user_password_url}?e"
+        end
       end
     end
 
-    context 'when the email is valid' do
-      let(:email) { 'test@test.com' }
+    context 'when the email is valid but an exception is raised' do
+      before do
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_raise(error.new('Some context', 'Some message'))
+        # rubocop:enable RSpec/AnyInstance
+        post :create, params: { cognito_forgot_password: { email: 'test@test.com' } }
+      end
 
-      it 'redirects to the edit password page' do
-        expect(response.location.split('=')[0]).to eq "#{base_edit_user_password_url}?e"
+      context 'and the error is UserNotFoundException' do
+        let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
+
+        it 'redirects to the edit password page' do
+          expect(response.location.split('=')[0]).to eq "#{base_edit_user_password_url}?e"
+        end
+      end
+
+      context 'and the error is InvalidParameterException' do
+        let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
+
+        it 'render to the new page' do
+          expect(response).to render_template(:new)
+        end
+      end
+
+      context 'and the error is ServiceError' do
+        let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
+
+        it 'render to the new page' do
+          expect(response).to render_template(:new)
+        end
       end
     end
   end

--- a/spec/services/cognito/forgot_password_spec.rb
+++ b/spec/services/cognito/forgot_password_spec.rb
@@ -88,9 +88,9 @@ RSpec.describe Cognito::ForgotPassword do
       context 'and the error is UserNotFoundException' do
         let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
 
-        it 'sets the error and success will be false' do
-          expect(forgot_password.errors[:base].first).to eq 'Please check the information you have entered'
-          expect(forgot_password.success?).to be false
+        it 'does not set an error and success will be true' do
+          expect(forgot_password.errors.none?).to be true
+          expect(forgot_password.success?).to be true
         end
       end
 

--- a/spec/services/cognito/sign_in_user_spec.rb
+++ b/spec/services/cognito/sign_in_user_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe Cognito::SignInUser do
         allow(client).to receive(:describe_user_pool_client).and_return(client_creds)
         allow(client_creds).to receive(:user_pool_client).and_return(user_pool_client)
         allow(user_pool_client).to receive(:explicit_auth_flows).and_return(explicit_auth_flows)
+        allow(sign_in_user).to receive(:sleep)
       end
 
       context 'and the explicit_auth_flows includes "USER_PASSWORD_AUTH"' do


### PR DESCRIPTION
Ticket: [PM-92](https://crowncommercialservice.atlassian.net/browse/PM-92)

Made updates to address various issues where it could be possible to enumerate emails of our users.

The first issue was with ‘Reset password’. Previously, an error message would have appeared if an account with the entered email address did not exist but now we have the same response as if a user with the email address did exist. This is so someone couldn’t just put in email addresses to work out who does and doesn’t have accounts.

The second issue was with the sign in and the response time. If the login credentials were invalid, the system would respond a lot quicker then if they were valid. The `go_then_wait` method extends the response time so that it is at least two seconds. This is longer then both a valid and invalid response so a nefarious user should not be able to infer if a user with the entered email address does or does not exist.