### PR TITLE
PM-92 - Prevent user enumeration when creating an account

### DIFF
--- a/app/services/cognito/confirm_sign_up.rb
+++ b/app/services/cognito/confirm_sign_up.rb
@@ -21,6 +21,9 @@ module Cognito
 
     def call
       confirm_sign_up if valid?
+    rescue Aws::CognitoIdentityProvider::Errors::NotAuthorizedException
+      # We do nothing as we don't want people to be able enumerate users
+      errors.add(:confirmation_code, :invalid)
     rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
       errors.add(:confirmation_code, e.message)
     end

--- a/app/services/cognito/sign_up_user.rb
+++ b/app/services/cognito/sign_up_user.rb
@@ -35,6 +35,8 @@ module Cognito
         resp = create_cognito_user
         @cognito_uuid = resp['user_sub']
       end
+    rescue Aws::CognitoIdentityProvider::Errors::UsernameExistsException
+      # We do nothing as we don't want people to be able enumerate users
     rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
       errors.add(:base, e.message)
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,6 +70,7 @@ en:
           attributes:
             confirmation_code:
               blank: Enter your verification code
+              invalid: Invalid verification code provided, please try again.
               invalid_format: Confirmation code must contain numeric characters only
               invalid_length: Confirmation code must be 6 characters
             email:

--- a/spec/services/cognito/confirm_sign_up_spec.rb
+++ b/spec/services/cognito/confirm_sign_up_spec.rb
@@ -108,13 +108,26 @@ RSpec.describe Cognito::ConfirmSignUp do
 
     context 'when there are errors' do
       before do
-        allow(client).to receive(:confirm_sign_up).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('Some context', 'Some message'))
+        allow(client).to receive(:confirm_sign_up).and_raise(error.new('Some context', 'Some message'))
         confirm_sign_up.call
       end
 
-      it 'sets the error and success will be false' do
-        expect(confirm_sign_up.errors[:confirmation_code].first).to eq 'Some message'
-        expect(confirm_sign_up.success?).to be false
+      context 'and the error is generic' do
+        let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
+
+        it 'sets the error and success will be false' do
+          expect(confirm_sign_up.errors[:confirmation_code].first).to eq 'Some message'
+          expect(confirm_sign_up.success?).to be false
+        end
+      end
+
+      context 'and the error is NotAuthorizedException' do
+        let(:error) { Aws::CognitoIdentityProvider::Errors::NotAuthorizedException }
+
+        it 'sets the error and success will be false' do
+          expect(confirm_sign_up.errors[:confirmation_code].first).to eq 'Invalid verification code provided, please try again.'
+          expect(confirm_sign_up.success?).to be false
+        end
       end
     end
   end

--- a/spec/services/cognito/sign_up_user_spec.rb
+++ b/spec/services/cognito/sign_up_user_spec.rb
@@ -339,13 +339,25 @@ RSpec.describe Cognito::SignUpUser do
 
     context 'when an error is raised' do
       before do
-        allow(client).to receive(:sign_up).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('Some context', 'Some message'))
+        allow(client).to receive(:sign_up).and_raise(error.new('Some context', 'Some message'))
         sign_up_user.call
       end
 
-      it 'sets the error and success will be false' do
-        expect(sign_up_user.errors[:base].first).to eq 'Some message'
-        expect(sign_up_user.success?).to be false
+      context 'and the error is generic' do
+        let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
+
+        it 'sets the error and success will be false' do
+          expect(sign_up_user.errors[:base].first).to eq 'Some message'
+          expect(sign_up_user.success?).to be false
+        end
+      end
+
+      context 'and the error is UsernameExistsException' do
+        let(:error) { Aws::CognitoIdentityProvider::Errors::UsernameExistsException }
+
+        it 'success will be true' do
+          expect(sign_up_user.success?).to be true
+        end
       end
     end
   end


### PR DESCRIPTION
Ticket: [PM-92](https://crowncommercialservice.atlassian.net/browse/PM-92)

Update the logic so that we let the user pass through if an account with that email already exists. This raises a `NotAuthorizedException` if the user enters anything in the next page and we account for that by showing the invalid code error message.