### PR TITLE
PM-104 - Fix issue where cookie is not deleted properly

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -13,7 +13,7 @@ class HomeController < ApplicationController
     update_cookie_preferences
 
     cookies[PmpIdam.cookie_settings_name] = {
-      value: cookie_preferences_settings.to_json,
+      value: helpers.cookie_preferences_settings.to_json,
       expires: 1.year.from_now
     }
 
@@ -27,22 +27,14 @@ class HomeController < ApplicationController
 
   private
 
-  def cookie_preferences_settings
-    @cookie_preferences_settings ||= begin
-      current_cookie_preferences = JSON.parse(cookies[PmpIdam.cookie_settings_name] || '{}')
-
-      current_cookie_preferences.empty? ? PmpIdam.default_cookie_options : current_cookie_preferences
-    end
-  end
-
   def update_cookie_preferences
     cookie_prefixes = []
 
     COOKIE_UPDATE_OPTIONS.each do |cookie_update_option|
       if params[cookie_update_option[:param_name]] == 'true'
-        cookie_preferences_settings[cookie_update_option[:cookie_name]] = true
+        helpers.cookie_preferences_settings[cookie_update_option[:cookie_name]] = true
       else
-        cookie_preferences_settings[cookie_update_option[:cookie_name]] = false
+        helpers.cookie_preferences_settings[cookie_update_option[:cookie_name]] = false
 
         cookie_prefixes += cookie_update_option[:cookie_prefixes]
       end
@@ -50,7 +42,7 @@ class HomeController < ApplicationController
 
     delete_unwanted_cookie(cookie_prefixes)
 
-    cookie_preferences_settings['settings_viewed'] = true
+    helpers.cookie_preferences_settings['settings_viewed'] = true
   end
 
   def delete_unwanted_cookie(cookie_prefixes)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,7 +40,7 @@ module ApplicationHelper
     @cookie_preferences_settings ||= begin
       current_cookie_preferences = JSON.parse(cookies[PmpIdam.cookie_settings_name] || '{}')
 
-      current_cookie_preferences.empty? ? PmpIdam.default_cookie_options : current_cookie_preferences
+      !current_cookie_preferences.is_a?(Hash) || current_cookie_preferences.empty? ? PmpIdam.default_cookie_options : current_cookie_preferences
     end
   end
 end

--- a/app/javascript/packs/cookie-policy.js
+++ b/app/javascript/packs/cookie-policy.js
@@ -1,3 +1,41 @@
+import Cookies from "js-cookie";
+
+const cookieUpdateOptions = [
+  {
+    cookieName: 'google_analytics_enabled',
+    cookiePrefixes: ['_ga', '_gi'],
+  },
+  {
+    cookieName: 'glassbox_enabled',
+    cookiePrefixes: ['_cls'],
+  },
+];
+
+const getCookiePreferences = () => {
+  const defaultCookieSettings = '{"google_analytics_enabled":true,"glassbox_enabled":false}';
+
+  return JSON.parse(Cookies.get('crown_marketplace_cookie_options_v1') || defaultCookieSettings);
+};
+
+const removeUnwantedCookies = () => {
+  const cookieList = Object.keys(Cookies.get());
+  const cookiesToRemove = ['pmp_cookie_settings_viewed', 'pmp_google_analytics_enabled'];
+  const cookiePreferences = getCookiePreferences();
+  const cookiePrefixes = [];
+
+  cookieUpdateOptions.forEach((cookieUpdateOption) => {
+    if (!cookiePreferences[cookieUpdateOption.cookieName]) cookiePrefixes.push(...cookieUpdateOption.cookiePrefixes);
+  });
+
+  for (let i = 0; i < cookieList.length; i++) {
+    const cookieName = cookieList[i];
+
+    if (cookiePrefixes.some((cookiePrefix) => cookieName.startsWith(cookiePrefix))) cookiesToRemove.push(cookieName);
+  }
+
+  cookiesToRemove.forEach((cookieName) => Cookies.remove(cookieName, { path: '/', domain: '.crowncommercial.gov.uk' }));
+};
+
 const removeGACookies = (formData, successFunction) => {
   let success = false;
 
@@ -36,11 +74,7 @@ const updateBanner = (isAccepeted, $newBanner) => {
 };
 
 $(() => {
-  const obsoleteCookies = ['pmp_cookie_settings_viewed', 'pmp_google_analytics_enabled'];
-
-  obsoleteCookies.forEach((cookieName) => {
-    if (document.cookie.includes(`${cookieName}=`)) document.cookie = `${cookieName}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
-  });
+  removeUnwantedCookies();
 
   $('[name="cookies"]').on('click', (event) => {
     event.preventDefault();

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "@rails/webpacker": "5.4.3",
     "accessible-autocomplete": "^2.0.4",
     "govuk-frontend": "^4.3.1",
-    "jquery": "^3.6.1"
+    "jquery": "^3.6.1",
+    "js-cookie": "^3.0.1"
   },
   "version": "0.1.0",
   "devDependencies": {

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -77,34 +77,44 @@ RSpec.describe ApplicationHelper do
 
   describe '.cookie_preferences_settings' do
     let(:result) { helper.cookie_preferences_settings }
+    let(:default_cookie_settings) do
+      {
+        'settings_viewed' => false,
+        'google_analytics_enabled' => false,
+        'glassbox_enabled' => false
+      }
+    end
 
     context 'when the cookie has not been set' do
-      let(:expected_cookie_settings) do
-        {
-          'settings_viewed' => false,
-          'google_analytics_enabled' => false,
-          'glassbox_enabled' => false
-        }
-      end
-
       it 'returns the default settings' do
-        expect(result).to eq(expected_cookie_settings)
+        expect(result).to eq(default_cookie_settings)
       end
     end
 
     context 'when the cookie has been set' do
-      let(:expected_cookie_settings) do
-        {
-          'settings_viewed' => true,
-          'google_analytics_enabled' => true,
-          'glassbox_enabled' => false
-        }
+      before { helper.request.cookies['pmp_cookie_options_v1'] = cookie_settings }
+
+      context 'and it is a hash' do
+        let(:expected_cookie_settings) do
+          {
+            'settings_viewed' => true,
+            'google_analytics_enabled' => true,
+            'glassbox_enabled' => false
+          }
+        end
+        let(:cookie_settings) { expected_cookie_settings.to_json }
+
+        it 'returns the settings from the cookie' do
+          expect(result).to eq(expected_cookie_settings)
+        end
       end
 
-      it 'returns the settings from the cookie' do
-        helper.request.cookies['pmp_cookie_options_v1'] = expected_cookie_settings.to_json
+      context 'and it is not a hash' do
+        let(:cookie_settings) { '123' }
 
-        expect(result).to eq(expected_cookie_settings)
+        it 'returns the default settings' do
+          expect(result).to eq(default_cookie_settings)
+        end
       end
     end
   end

--- a/yarn.lock
+++ b/yarn.lock
@@ -3983,6 +3983,11 @@ jquery@^3.6.1:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.1.tgz#fab0408f8b45fc19f956205773b62b292c147a16"
   integrity sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==
 
+js-cookie@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
+  integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
Ticket: [PM-104](https://crowncommercialservice.atlassian.net/browse/PM-104)

Fix an issue where cookie is not removed when JS is enabled due to GA creating the cookie when the website is reloaded
