### PR TITLE
Use GitHub actions to run unit tests instead of Travis CI

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -1,0 +1,52 @@
+name: "Ruby on Rails CI"
+
+on:
+  push:
+    branches-ignore:
+      - develop
+      - staging
+      - main
+  pull_request:
+
+jobs:
+  unit-test:
+    runs-on: ubuntu-20.04
+
+    services:
+      postgres:
+        image: postgis/postgis:11-2.5
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_DB: rails_test
+          POSTGRES_USER: rails
+          POSTGRES_PASSWORD: password
+
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: "postgis://rails:password@localhost:5432/rails_test"
+      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1.138.0
+        with:
+          bundler-cache: true
+
+      - name: Set up database schema
+        run: bin/rails db:test:prepare
+
+      - name: Compile assets
+        run: NODE_OPTIONS=--openssl-legacy-provider bin/rails assets:precompile
+
+      - name: Run unit tests
+        run: bin/rake
+
+      - name: publish code coverage
+        uses: paambaati/codeclimate-action@v3.2.0
+        with:
+          debug: true
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'develop' }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ deploy:
     repo: Crown-Commercial-Service/pmp-idam
     all_branches: true
     condition: $DEPLOY_BRANCH = TRUE
+branches:
+  only:
+    - develop
+    - staging
+    - main
 env:
   global:
     - RAILS_ENV=test

--- a/spec/controllers/api/v1/organisation_controller_spec.rb
+++ b/spec/controllers/api/v1/organisation_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::OrganisationController do
   describe 'GET search' do
-    let(:result) { JSON.parse(response.body) }
+    let(:result) { response.parsed_body }
 
     before { get :search, params: { search: search } }
 


### PR DESCRIPTION
As we will need to eventually move away from Travis, I have added GitHub actions to run the unit tests in preoration.