### PR TITLE
PM-114 - Update the cookie names to match the unified approach

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -56,12 +56,12 @@ class HomeController < ApplicationController
   COOKIE_UPDATE_OPTIONS = [
     {
       param_name: :ga_cookie_usage,
-      cookie_name: 'google_analytics_enabled',
+      cookie_name: 'usage',
       cookie_prefixes: %w[_ga _gi]
     },
     {
       param_name: :glassbox_cookie_usage,
-      cookie_name: 'glassbox_enabled',
+      cookie_name: 'glassbox',
       cookie_prefixes: %w[_cls]
     }
   ].freeze

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,6 +10,7 @@ require("packs/cp-sign-in")
 require('packs/autocomplete')
 require('packs/error-links')
 require('packs/cookie-policy')
+require('packs/google-analytics-data-layer')
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/javascript/packs/cookie-policy.js
+++ b/app/javascript/packs/cookie-policy.js
@@ -2,24 +2,24 @@ import Cookies from "js-cookie";
 
 const cookieUpdateOptions = [
   {
-    cookieName: 'google_analytics_enabled',
+    cookieName: 'usage',
     cookiePrefixes: ['_ga', '_gi'],
   },
   {
-    cookieName: 'glassbox_enabled',
+    cookieName: 'glassbox',
     cookiePrefixes: ['_cls'],
   },
 ];
 
 const getCookiePreferences = () => {
-  const defaultCookieSettings = '{"google_analytics_enabled":true,"glassbox_enabled":false}';
+  const defaultCookieSettings = '{"usage":true,"glassbox":false}';
 
   return JSON.parse(Cookies.get('crown_marketplace_cookie_options_v1') || defaultCookieSettings);
 };
 
 const removeUnwantedCookies = () => {
   const cookieList = Object.keys(Cookies.get());
-  const cookiesToRemove = ['pmp_cookie_settings_viewed', 'pmp_google_analytics_enabled'];
+  const cookiesToRemove = ['pmp_cookie_settings_viewed', 'pmp_google_analytics_enabled', 'pmp_cookie_options_v1'];
   const cookiePreferences = getCookiePreferences();
   const cookiePrefixes = [];
 

--- a/app/javascript/packs/google-analytics-data-layer.js
+++ b/app/javascript/packs/google-analytics-data-layer.js
@@ -1,0 +1,38 @@
+import Cookies from 'js-cookie'
+
+const grantType = {
+  granted: 'granted',
+  notGranted: 'not granted'
+}
+
+const getCookiePreferences = () => Cookies.get('cookie_preferences') ?? '{}'
+
+const getCookiePreferencesSaved = () => Cookies.get('cookie_preferences_saved') ?? '{}'
+
+const setCookiePreferencesSaved = (cookiePreferences) => {
+  Cookies.set('cookie_preferences_saved', JSON.stringify(cookiePreferences), { expires: 365 })
+}
+
+const getGrantedText = (state) => state ? grantType.granted : grantType.notGranted
+
+const updateDataLayer = (cookiePreferences) => {
+  window.dataLayer.push({
+    event: 'gtm_consent_update',
+    usage_consent: getGrantedText(cookiePreferences.usage),
+    glassbox_consent: getGrantedText(cookiePreferences.glassbox),
+    marketing_consent: grantType.notGranted
+  })
+
+  setCookiePreferencesSaved(cookiePreferences)
+}
+
+$(() => {
+  if (window.dataLayer) {
+    const cookiePreferences = getCookiePreferences()
+    const cookiePreferencesSaved = getCookiePreferencesSaved()
+
+    if (cookiePreferences !== cookiePreferencesSaved) {
+      updateDataLayer(JSON.parse(cookiePreferences))
+    }
+  }
+})

--- a/app/views/home/cookie_policy.html.erb
+++ b/app/views/home/cookie_policy.html.erb
@@ -115,6 +115,11 @@
           <td class="govuk-table__cell govuk-!-padding-right-2"><%= t(".cookie_banner_cookies.row_1.purpose") %></td>
           <td class="govuk-table__cell govuk-!-padding-right-2"><%= t(".cookie_banner_cookies.row_1.expires") %></td>
         </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell govuk-!-padding-right-2" style="word-break: break-all;"><%= t(".cookie_banner_cookies.row_2.name") %></td>
+          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t(".cookie_banner_cookies.row_2.purpose") %></td>
+          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t(".cookie_banner_cookies.row_2.expires") %></td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/app/views/home/cookie_settings.html.erb
+++ b/app/views/home/cookie_settings.html.erb
@@ -63,11 +63,11 @@
 
         <div class="govuk-radios">
           <div class="govuk-radios__item">
-            <%= radio_button_tag :ga_cookie_usage, true, cookie_preferences_settings['google_analytics_enabled'], class: 'govuk-radios__input' %>
+            <%= radio_button_tag :ga_cookie_usage, true, cookie_preferences_settings['usage'], class: 'govuk-radios__input' %>
             <%= label_tag :ga_cookie_usage, t('.use_cookies.ga'), for: :ga_cookie_usage_true, class: 'govuk-label govuk-radios__label' %>
           </div>
           <div class="govuk-radios__item">
-            <%= radio_button_tag :ga_cookie_usage, false, !cookie_preferences_settings['google_analytics_enabled'], class: 'govuk-radios__input' %>
+            <%= radio_button_tag :ga_cookie_usage, false, !cookie_preferences_settings['usage'], class: 'govuk-radios__input' %>
             <%= label_tag :ga_cookie_usage, t('.dont_use_cookies.ga'), for: :ga_cookie_usage_false, class: 'govuk-label govuk-radios__label' %>
           </div>
         </div>
@@ -86,11 +86,11 @@
 
         <div class="govuk-radios">
           <div class="govuk-radios__item">
-            <%= radio_button_tag :glassbox_cookie_usage, true, cookie_preferences_settings['glassbox_enabled'], class: 'govuk-radios__input' %>
+            <%= radio_button_tag :glassbox_cookie_usage, true, cookie_preferences_settings['glassbox'], class: 'govuk-radios__input' %>
             <%= label_tag :glassbox_cookie_usage, t('.use_cookies.glassbox'), for: :glassbox_cookie_usage_true, class: 'govuk-label govuk-radios__label' %>
           </div>
           <div class="govuk-radios__item">
-            <%= radio_button_tag :glassbox_cookie_usage, false, !cookie_preferences_settings['glassbox_enabled'], class: 'govuk-radios__input' %>
+            <%= radio_button_tag :glassbox_cookie_usage, false, !cookie_preferences_settings['glassbox'], class: 'govuk-radios__input' %>
             <%= label_tag :glassbox_cookie_usage, t('.dont_use_cookies.glassbox'), for: :glassbox_cookie_usage_false, class: 'govuk-label govuk-radios__label' %>
           </div>
         </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -64,14 +64,14 @@ module PmpIdam
   end
 
   def self.cookie_settings_name
-    :pmp_cookie_options_v1
+    :cookie_preferences
   end
 
   def self.default_cookie_options
     {
       settings_viewed: false,
-      google_analytics_enabled: false,
-      glassbox_enabled: false
+      usage: false,
+      glassbox: false
     }.stringify_keys
   end
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
     policy.img_src     :self, :https, :data, 'https://*.google-analytics.com', 'https://*.googletagmanager.com'
     policy.object_src  :none
     policy.script_src  :self, :https, 'https://*.googletagmanager.com'
-    policy.style_src   :self, :https
+    policy.style_src   :self, "'unsafe-inline'", :https
     policy.connect_src :self, :https, 'https://*.google-analytics.com', 'https://*.analytics.google.com', 'https://*.googletagmanager.com'
     # Specify URI for violation reports
     # policy.report_uri "/csp-violation-report-endpoint"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -278,6 +278,10 @@ en:
         row_1:
           expires: 1 year
           purpose: Saves your cookie consent preferences
+        row_2:
+          expires: 1 year
+          name: cookie_preferences_saved
+          purpose: Allows us to check when your cookie settings have changed
       cookies_banner: Cookies banner
       ga_cookies:
         row_1:

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -40,11 +40,11 @@ RSpec.describe HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['pmp_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => true,
-            'glassbox_enabled' => false
+            'usage' => true,
+            'glassbox' => false
           }
         )
       end
@@ -76,11 +76,11 @@ RSpec.describe HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['pmp_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => false,
-            'glassbox_enabled' => true
+            'usage' => false,
+            'glassbox' => true
           }
         )
       end
@@ -112,11 +112,11 @@ RSpec.describe HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['pmp_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => true,
-            'glassbox_enabled' => true
+            'usage' => true,
+            'glassbox' => true
           }
         )
       end
@@ -140,11 +140,11 @@ RSpec.describe HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['pmp_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => false,
-            'glassbox_enabled' => false
+            'usage' => false,
+            'glassbox' => false
           }
         )
       end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -80,8 +80,8 @@ RSpec.describe ApplicationHelper do
     let(:default_cookie_settings) do
       {
         'settings_viewed' => false,
-        'google_analytics_enabled' => false,
-        'glassbox_enabled' => false
+        'usage' => false,
+        'glassbox' => false
       }
     end
 
@@ -92,14 +92,14 @@ RSpec.describe ApplicationHelper do
     end
 
     context 'when the cookie has been set' do
-      before { helper.request.cookies['pmp_cookie_options_v1'] = cookie_settings }
+      before { helper.request.cookies['cookie_preferences'] = cookie_settings }
 
       context 'and it is a hash' do
         let(:expected_cookie_settings) do
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => true,
-            'glassbox_enabled' => false
+            'usage' => true,
+            'glassbox' => false
           }
         end
         let(:cookie_settings) { expected_cookie_settings.to_json }


### PR DESCRIPTION
Ticket: [PM-114](https://crowncommercialservice.atlassian.net/browse/PM-114)

Update the cookie names to match the unified approach.
Add the data layer push for the GA consent mode.

[PM-114]: https://crowncommercialservice.atlassian.net/browse/PM-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ