### PR TITLE
Target a specific alpine version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
     schedule:
       interval: weekly
       day: sunday
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
 # Pass in nodejs version
-ARG NODE_VERSION=20.0.0
+ARG NODE_VERSION=20.10.0
 
 # Pass in ruby version
 ARG RUBY_VERSION=3.2.2
 
 # Pull in the nodejs image
-FROM node:${NODE_VERSION}-alpine AS node
-#FROM public.ecr.aws/docker/library/node:${NODE_VERSION}-alpine AS node
+FROM node:${NODE_VERSION}-alpine3.18 AS node
 
 # Pull in the ruby image
-FROM ruby:${RUBY_VERSION}-alpine
-#FROM public.ecr.aws/docker/library/ruby:${RUBY_VERSION}-alpine
+FROM ruby:${RUBY_VERSION}-alpine3.18
 
 # As this is a multistage Docker image build
 # we will pull in the contents from the previous node image build stage


### PR DESCRIPTION
I am unsure why but there seems to be an issue with the latest version of ruby alpine which uses alpine 3.19.

As such I have specified the alpine version in the Dockerfile to make sure we target one that works. What's more, we should make sure that both ruby and node are using the same version of alpine.