### PR TITLE
Workaround for Alpine 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ ARG NODE_VERSION=20.10.0
 ARG RUBY_VERSION=3.2.2
 
 # Pull in the nodejs image
-FROM node:${NODE_VERSION}-alpine3.18 AS node
+FROM node:${NODE_VERSION}-alpine3.19 AS node
 
 # Pull in the ruby image
-FROM ruby:${RUBY_VERSION}-alpine3.18
+FROM ruby:${RUBY_VERSION}-alpine3.19
 
 # As this is a multistage Docker image build
 # we will pull in the contents from the previous node image build stage
@@ -39,6 +39,11 @@ COPY Gemfile Gemfile.lock ./
 
 # Build application
 RUN gem install bundler && bundle install --jobs 4 --retry 5 && bundle clean --force
+
+# Recompile sqlite3 gem, fixes an issue with Alpine 3.19 where
+# sqlite3_native.so cannot be loaded due to missing symbols
+RUN gem uninstall sqlite3
+RUN gem install sqlite3 --platform=ruby
 
 RUN NODE_OPTIONS=--openssl-legacy-provider rake assets:precompile
 


### PR DESCRIPTION
There is an issue with Alpine 3.19 and sqlite libraries and 'symbols' not found:

```
/app # ldd /usr/local/bundle/gems/sqlite3-1.6.9-x86_64-linux/lib/sqlite3/3.2/sqlite3_native.so
        /lib/ld-musl-x86_64.so.1 (0x7f6a65ed8000)
        libz.so.1 => /lib/libz.so.1 (0x7f6a65d5d000)
        libm.so.6 => /lib/ld-musl-x86_64.so.1 (0x7f6a65ed8000)
        libdl.so.2 => /lib/ld-musl-x86_64.so.1 (0x7f6a65ed8000)
        libpthread.so.0 => /lib/ld-musl-x86_64.so.1 (0x7f6a65ed8000)
        libc.so.6 => /lib/ld-musl-x86_64.so.1 (0x7f6a65ed8000)
Error relocating /usr/local/bundle/gems/sqlite3-1.6.9-x86_64-linux/lib/sqlite3/3.2/sqlite3_native.so: rb_iv_get: symbol not found
Error relocating /usr/local/bundle/gems/sqlite3-1.6.9-x86_64-linux/lib/sqlite3/3.2/sqlite3_native.so: rb_ll2inum: symbol not found
Error relocating /usr/local/bundle/gems/sqlite3-1.6.9-x86_64-linux/lib/sqlite3/3.2/sqlite3_native.so: rb_string_value_cstr: symbol not found
Error relocating /usr/local/bundle/gems/sqlite3-1.6.9-x86_64-linux/lib/sqlite3/3.2/sqlite3_native.so: rb_raise: symbol not found
Error relocating /usr/local/bundle/gems/sqlite3-1.6.9-x86_64-linux/lib/sqlite3/3.2/sqlite3_native.so: rb_block_proc: symbol not found
Error relocating /usr/local/bundle/gems/sqlite3-1.6.9-x86_64-linux/lib/sqlite3/3.2/sqlite3_native.so: rb_exc_new_cstr: symbol not found
Error relocating /usr/local/bundle/gems/sqlite3-1.6.9-x86_64-linux/lib/sqlite3/3.2/sqlite3_native.so: rb_errinfo: symbol not found
Error relocating /usr/local/bundle/gems/sqlite3-1.6.9-x86_64-linux/lib/sqlite3/3.2/sqlite3_native.so: rb_utf8_encindex: symbol not found
Error relocating /usr/local/bundle/gems/sqlite3-1.6.9-x86_64-linux/lib/sqlite3/3.2/sqlite3_native.so: rb_num2dbl: symbol not found
```

Recompiling the sqlite gem during the image build resolves this. 